### PR TITLE
Modernize WPF inventory UI

### DIFF
--- a/HomeInventory/HomeInventory.Desktop.Wpf/App.xaml
+++ b/HomeInventory/HomeInventory.Desktop.Wpf/App.xaml
@@ -9,11 +9,73 @@
         
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="DeepPurple" SecondaryColor="Lime" />
+                <materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="Indigo" SecondaryColor="Teal" />
 
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign2.Defaults.xaml" />
 
             </ResourceDictionary.MergedDictionaries>
+
+            <Color x:Key="AppBackgroundColor">#F5F7FB</Color>
+            <Color x:Key="AppSurfaceColor">#FFFFFFFF</Color>
+            <Color x:Key="AppSurfaceMutedColor">#EEF3F8</Color>
+            <Color x:Key="AppBorderColor">#D8E0EA</Color>
+            <Color x:Key="AppTextColor">#172033</Color>
+            <Color x:Key="AppMutedTextColor">#667085</Color>
+            <Color x:Key="AppAccentColor">#0F766E</Color>
+
+            <SolidColorBrush x:Key="AppBackgroundBrush" Color="{StaticResource AppBackgroundColor}" />
+            <SolidColorBrush x:Key="AppSurfaceBrush" Color="{StaticResource AppSurfaceColor}" />
+            <SolidColorBrush x:Key="AppSurfaceMutedBrush" Color="{StaticResource AppSurfaceMutedColor}" />
+            <SolidColorBrush x:Key="AppBorderBrush" Color="{StaticResource AppBorderColor}" />
+            <SolidColorBrush x:Key="AppTextBrush" Color="{StaticResource AppTextColor}" />
+            <SolidColorBrush x:Key="AppMutedTextBrush" Color="{StaticResource AppMutedTextColor}" />
+            <SolidColorBrush x:Key="AppAccentBrush" Color="{StaticResource AppAccentColor}" />
+
+            <Style x:Key="PageTitleText" TargetType="{x:Type TextBlock}">
+                <Setter Property="Foreground" Value="{StaticResource AppTextBrush}" />
+                <Setter Property="FontSize" Value="22" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+                <Setter Property="LineHeight" Value="28" />
+            </Style>
+
+            <Style x:Key="SectionTitleText" TargetType="{x:Type TextBlock}">
+                <Setter Property="Foreground" Value="{StaticResource AppTextBrush}" />
+                <Setter Property="FontSize" Value="15" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+            </Style>
+
+            <Style x:Key="CaptionText" TargetType="{x:Type TextBlock}">
+                <Setter Property="Foreground" Value="{StaticResource AppMutedTextBrush}" />
+                <Setter Property="FontSize" Value="12" />
+            </Style>
+
+            <Style x:Key="IconToolButton" TargetType="{x:Type Button}">
+                <Setter Property="Width" Value="36" />
+                <Setter Property="Height" Value="36" />
+                <Setter Property="MinWidth" Value="36" />
+                <Setter Property="Padding" Value="0" />
+                <Setter Property="Margin" Value="6,0,0,0" />
+                <Setter Property="ToolTipService.InitialShowDelay" Value="350" />
+            </Style>
+
+            <Style x:Key="PrimaryActionButton" TargetType="{x:Type Button}">
+                <Setter Property="MinHeight" Value="38" />
+                <Setter Property="Padding" Value="16,0" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+            </Style>
+
+            <Style x:Key="SoftPanelBorder" TargetType="{x:Type Border}">
+                <Setter Property="Background" Value="{StaticResource AppSurfaceBrush}" />
+                <Setter Property="BorderBrush" Value="{StaticResource AppBorderBrush}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="8" />
+            </Style>
+
+            <Style x:Key="OverlayPanel" TargetType="{x:Type Border}">
+                <Setter Property="Background" Value="#C8F5F7FB" />
+                <Setter Property="Panel.ZIndex" Value="10" />
+            </Style>
+
             <DataTemplate DataType="{x:Type vm:LoginViewModel}">
                     <views:LoginView />
             </DataTemplate>

--- a/HomeInventory/HomeInventory.Desktop.Wpf/ViewModels/LocationDetailViewModel.cs
+++ b/HomeInventory/HomeInventory.Desktop.Wpf/ViewModels/LocationDetailViewModel.cs
@@ -19,6 +19,9 @@ namespace HomeInventory.Desktop.Wpf.ViewModels
 
         private LocationNodeViewModel? _node;
         private Location? _location;
+        private bool _suppressAutoSave;
+        private readonly SemaphoreSlim _autoSaveGate = new(1, 1);
+        private int _autoSaveVersion;
 
         public IReadOnlyList<LocationType> LocationTypes { get; } = Enum.GetValues<LocationType>();
 
@@ -75,9 +78,7 @@ namespace HomeInventory.Desktop.Wpf.ViewModels
                     var location = await _locations.GetByIdAsync(node.Id, ct);
                     _node = node;
                     _location = location;
-                    Name = location.Name;
-                    SelectedLocationType = location.LocationType;
-                    Description = location.Description;
+                    SetFieldsFromLocation(location);
                     OnPropertyChanged(nameof(HasLocation));
                     SaveCommand.NotifyCanExecuteChanged();
                 }
@@ -94,9 +95,17 @@ namespace HomeInventory.Desktop.Wpf.ViewModels
         {
             _node = null;
             _location = null;
-            Name = null;
-            Description = null;
-            SelectedLocationType = default;
+            _suppressAutoSave = true;
+            try
+            {
+                Name = null;
+                Description = null;
+                SelectedLocationType = default;
+            }
+            finally
+            {
+                _suppressAutoSave = false;
+            }
             OnPropertyChanged(nameof(HasLocation));
             SaveCommand.NotifyCanExecuteChanged();
         }
@@ -106,15 +115,15 @@ namespace HomeInventory.Desktop.Wpf.ViewModels
 
         [RelayCommand(CanExecute = nameof(CanSave))]
         private async Task Save()
+            => await SaveCore(CancellationToken.None);
+
+        private async Task SaveCore(CancellationToken ct)
         {
             if (_location is null || _node is null)
                 return;
 
             if (string.IsNullOrWhiteSpace(Name))
-            {
-                _dialogs.ShowError("Operace selhala", "Jmeno musi byt vyplneno!");
                 return;
-            }
 
             var request = new LocationUpdateRequest(
                 Name.Trim(),
@@ -127,13 +136,14 @@ namespace HomeInventory.Desktop.Wpf.ViewModels
             {
                 try
                 {
-                    var updated = await _locations.UpdateAsync(_location.Id, request, new CancellationTokenSource().Token);
+                    var updated = await _locations.UpdateAsync(_location.Id, request, ct);
                     _location = updated;
                     _node.SetLocation(LocationMapping.MapToListItem(updated));
-                    Name = updated.Name;
-                    SelectedLocationType = updated.LocationType;
-                    Description = updated.Description;
+                    SetFieldsFromLocation(updated);
                     _notifications.Success("Ulozeno");
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
                 }
                 catch (Exception ex) when (ex is ApiException || ex is InvalidOperationException)
                 {
@@ -143,6 +153,56 @@ namespace HomeInventory.Desktop.Wpf.ViewModels
                     _dialogs.ShowError("Operace selhala", message);
                 }
             });
+        }
+
+        partial void OnNameChanged(string? value)
+            => QueueAutoSave();
+
+        partial void OnSelectedLocationTypeChanged(LocationType value)
+            => QueueAutoSave();
+
+        partial void OnDescriptionChanged(string? value)
+            => QueueAutoSave();
+
+        private void QueueAutoSave()
+        {
+            if (_suppressAutoSave || !CanSave())
+                return;
+
+            var version = Interlocked.Increment(ref _autoSaveVersion);
+            _ = SaveLatestChangeAsync(version);
+        }
+
+        private async Task SaveLatestChangeAsync(int version)
+        {
+            await _autoSaveGate.WaitAsync();
+            try
+            {
+                if (version != _autoSaveVersion)
+                    return;
+
+                await SaveCore(CancellationToken.None);
+            }
+            finally
+            {
+                _autoSaveGate.Release();
+            }
+        }
+
+
+        private void SetFieldsFromLocation(Location location)
+        {
+            _suppressAutoSave = true;
+            try
+            {
+                Name = location.Name;
+                SelectedLocationType = location.LocationType;
+                Description = location.Description;
+            }
+            finally
+            {
+                _suppressAutoSave = false;
+            }
         }
     }
 }

--- a/HomeInventory/HomeInventory.Desktop.Wpf/Views/ItemsListView.xaml
+++ b/HomeInventory/HomeInventory.Desktop.Wpf/Views/ItemsListView.xaml
@@ -13,43 +13,66 @@
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
         <Style x:Key="NameTemplate" TargetType="{x:Type TextBox}">
             <Setter Property="MaxLength" Value="20" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
         </Style>
         <Style x:Key="DescPlaceNoteTemplate" TargetType="{x:Type TextBox}">
             <Setter Property="MaxLength" Value="100" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
         </Style>
     </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="30" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Grid Grid.Row="0">
+        <Grid Grid.Row="0" Margin="0,0,0,14">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <Button Command="{Binding AddItemCommand}" Margin="0,0,8,0" Grid.Column="1">
+            <StackPanel Grid.Column="0">
+                <TextBlock Text="Položky" Style="{StaticResource SectionTitleText}" />
+                <TextBlock Text="Upravujte názvy, počty a poznámky přímo v tabulce." Style="{StaticResource CaptionText}" Margin="0,3,0,0" />
+            </StackPanel>
+            <Button Command="{Binding AddItemCommand}" Grid.Column="1" Style="{StaticResource IconToolButton}" ToolTip="Přidat položku">
                 <materialDesign:PackIcon Kind="Add" Width="20" Height="20"/>
             </Button>
-            <Button Command="{Binding DeleteItemCommand}" Margin="0,0,8,0" Grid.Column="2">
+            <Button Command="{Binding DeleteItemCommand}" Grid.Column="2" Style="{StaticResource IconToolButton}" ToolTip="Smazat vybrané položky">
                 <materialDesign:PackIcon Kind="Delete" Width="20" Height="20"/>
             </Button>
-            <Button Command="{Binding MoveToLocationCommand}" Margin="0,0,8,0" Grid.Column="3">
+            <Button Command="{Binding MoveToLocationCommand}" Grid.Column="3" Style="{StaticResource IconToolButton}" ToolTip="Přesunout vybrané položky">
                 <materialDesign:PackIcon Kind="SwapHorizontal" Width="20" Height="20"/>
             </Button>
         </Grid>
-        <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedItem}" CanUserAddRows="False" x:Name="ItemsGrid" Loaded="DataGrid_Loaded" IsReadOnly="{Binding IsBusy}"  Grid.Row="1">
+        <DataGrid ItemsSource="{Binding Items}"
+                  AutoGenerateColumns="False"
+                  SelectedItem="{Binding SelectedItem}"
+                  CanUserAddRows="False"
+                  x:Name="ItemsGrid"
+                  Loaded="DataGrid_Loaded"
+                  IsReadOnly="{Binding IsBusy}"
+                  Grid.Row="1"
+                  HeadersVisibility="Column"
+                  RowHeight="44"
+                  ColumnHeaderHeight="42"
+                  GridLinesVisibility="None"
+                  BorderThickness="1"
+                  BorderBrush="{StaticResource AppBorderBrush}"
+                  Background="{StaticResource AppSurfaceBrush}"
+                  AlternatingRowBackground="{StaticResource AppSurfaceMutedBrush}"
+                  HorizontalGridLinesBrush="{StaticResource AppBorderBrush}"
+                  VerticalGridLinesBrush="{StaticResource AppBorderBrush}">
 
             <DataGrid.Columns>
-                <DataGridCheckBoxColumn Binding="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsThreeState = "False"/>
+                <DataGridCheckBoxColumn Binding="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsThreeState = "False" Width="64" MinWidth="64"/>
 
-                <DataGridTextColumn EditingElementStyle="{StaticResource NameTemplate}" Header="Name" Binding="{Binding Name, UpdateSourceTrigger=LostFocus}" />
-                <DataGridTemplateColumn Header="Quantity">
+                <DataGridTextColumn EditingElementStyle="{StaticResource NameTemplate}" Header="Název" Binding="{Binding Name, UpdateSourceTrigger=LostFocus}" Width="2*" />
+                <DataGridTemplateColumn Header="Počet" Width="110">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <TextBlock Text="{Binding Quantity}" />
+                            <TextBlock Text="{Binding Quantity}" VerticalAlignment="Center" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                     <DataGridTemplateColumn.CellEditingTemplate>
@@ -58,17 +81,17 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTextColumn EditingElementStyle="{StaticResource DescPlaceNoteTemplate}" Header="Placement Note" Binding="{Binding PlacementNote, UpdateSourceTrigger=LostFocus}" />
-                <DataGridTextColumn EditingElementStyle="{StaticResource DescPlaceNoteTemplate}" Header="Description" Binding="{Binding Description, UpdateSourceTrigger=LostFocus}" />
+                <DataGridTextColumn EditingElementStyle="{StaticResource DescPlaceNoteTemplate}" Header="Umístění" Binding="{Binding PlacementNote, UpdateSourceTrigger=LostFocus}" Width="2*" />
+                <DataGridTextColumn EditingElementStyle="{StaticResource DescPlaceNoteTemplate}" Header="Popis" Binding="{Binding Description, UpdateSourceTrigger=LostFocus}" Width="2*" />
             </DataGrid.Columns>
         </DataGrid>
 
-        <Border Background="#66FFFFFF"
-    Visibility="{Binding IsSelectingNewLocation, Converter={StaticResource BoolToVisibilityConverter}}"
-    Panel.ZIndex="10" Grid.Row="1">
-            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                <ProgressBar Width="140" Height="6" IsIndeterminate="True"/>
-                <TextBlock Text="Vyber novou lokaci..." Margin="0,8,0,0" HorizontalAlignment="Center"/>
+        <Border Style="{StaticResource OverlayPanel}"
+                Visibility="{Binding IsSelectingNewLocation, Converter={StaticResource BoolToVisibilityConverter}}"
+                Grid.Row="1">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="240">
+                <ProgressBar Height="6" IsIndeterminate="True"/>
+                <TextBlock Text="Vyberte cílovou lokaci..." Margin="0,12,0,0" HorizontalAlignment="Center" Style="{StaticResource CaptionText}"/>
             </StackPanel>
         </Border>
 

--- a/HomeInventory/HomeInventory.Desktop.Wpf/Views/ItemsSearchView.xaml
+++ b/HomeInventory/HomeInventory.Desktop.Wpf/Views/ItemsSearchView.xaml
@@ -4,18 +4,38 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:HomeInventory.Desktop.Wpf.Views"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
-    <StackPanel Margin="24" Width="520">
-        <TextBlock Text="Search" FontSize="22" Margin="0,0,0,16"/>
-        <StackPanel Orientation="Horizontal">
-            <TextBox Width="300" Margin="0,0,8,0"
-                     Text="{Binding Query, UpdateSourceTrigger=PropertyChanged}"/>
-            <Button Content="Hledat" Command="{Binding SearchCommand}" />
-            <Button Content="Odhlásit" Margin="8,0,0,0"
-                    Command="{Binding LogoutCommand}" />
+    <Grid Background="{StaticResource AppBackgroundBrush}" Margin="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,18">
+            <TextBlock Text="Vyhledávání" Style="{StaticResource PageTitleText}" />
+            <TextBlock Text="Najděte položky napříč uloženými lokacemi." Style="{StaticResource CaptionText}" Margin="0,4,0,0" />
         </StackPanel>
 
-        <ListBox Margin="0,16,0,0" ItemsSource="{Binding Results}" Height="220"/>
-    </StackPanel>
+        <Grid Grid.Row="1" Margin="0,0,0,18">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBox Grid.Column="0"
+                     MinHeight="42"
+                     Margin="0,0,10,0"
+                     materialDesign:HintAssist.Hint="Hledaný výraz"
+                     Text="{Binding Query, UpdateSourceTrigger=PropertyChanged}"/>
+            <Button Grid.Column="1" Content="Hledat" Command="{Binding SearchCommand}" Style="{StaticResource PrimaryActionButton}" />
+            <Button Grid.Column="2" Content="Odhlásit" Margin="10,0,0,0" Command="{Binding LogoutCommand}" MinHeight="38" Padding="14,0" />
+        </Grid>
+
+        <Border Grid.Row="2" Style="{StaticResource SoftPanelBorder}" Padding="8">
+            <ListBox ItemsSource="{Binding Results}" BorderThickness="0" Background="Transparent"/>
+        </Border>
+    </Grid>
 </UserControl>

--- a/HomeInventory/HomeInventory.Desktop.Wpf/Views/LocationDetailView.xaml
+++ b/HomeInventory/HomeInventory.Desktop.Wpf/Views/LocationDetailView.xaml
@@ -5,67 +5,88 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d"
-             d:DesignHeight="180" d:DesignWidth="800">
-    <Border BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-            BorderThickness="0,0,0,1"
-            Padding="0,0,0,12">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*"/>
-                <ColumnDefinition Width="160"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
+             d:DesignHeight="260" d:DesignWidth="800">
+    <Border Background="{StaticResource AppSurfaceMutedBrush}"
+            BorderBrush="{StaticResource AppBorderBrush}"
+            BorderThickness="1"
+            CornerRadius="8"
+            Padding="4">
+        <Expander IsExpanded="False"
+                  Background="Transparent"
+                  BorderThickness="0"
+                  Padding="0">
+            <Expander.Header>
+                <Grid MinHeight="40" Margin="8,0,12,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock Text="{Binding Name, TargetNullValue=Vyberte lokaci, FallbackValue=Vyberte lokaci}" Style="{StaticResource SectionTitleText}" />
+                        <TextBlock Text="{Binding Description, TargetNullValue=Bez popisu, FallbackValue=Bez popisu}"
+                                   Style="{StaticResource CaptionText}"
+                                   Margin="0,2,0,0"
+                                   TextTrimming="CharacterEllipsis"
+                                   TextWrapping="NoWrap" />
+                    </StackPanel>
+                    <materialDesign:PackIcon Grid.Column="1"
+                                             Kind="Pencil"
+                                             Width="18"
+                                             Height="18"
+                                             Foreground="{StaticResource AppMutedTextBrush}"
+                                             VerticalAlignment="Center"/>
+                </Grid>
+            </Expander.Header>
 
-            <TextBlock Grid.Row="0"
-                       Grid.ColumnSpan="3"
-                       Text="Detail lokace"
-                       FontSize="16"
-                       FontWeight="SemiBold"
-                       Margin="0,0,0,8"/>
+            <Grid Margin="12,8,12,12">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*"/>
+                    <ColumnDefinition Width="180"/>
+                </Grid.ColumnDefinitions>
 
-            <TextBox Grid.Row="1"
-                     Grid.Column="0"
-                     Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
-                     MaxLength="60"
-                     Margin="0,0,8,8"
-                     VerticalContentAlignment="Center"
-                     materialDesign:HintAssist.Hint="Nazev"
-                     IsEnabled="{Binding HasLocation}"/>
+                <TextBox Grid.Row="0"
+                         Grid.Column="0"
+                         Text="{Binding Name, UpdateSourceTrigger=LostFocus}"
+                         MaxLength="60"
+                         MinHeight="40"
+                         Margin="0,0,10,14"
+                         VerticalContentAlignment="Center"
+                         materialDesign:HintAssist.Hint="Název"
+                         IsEnabled="{Binding HasLocation}"/>
 
-            <ComboBox Grid.Row="1"
-                      Grid.Column="1"
-                      ItemsSource="{Binding LocationTypes}"
-                      SelectedItem="{Binding SelectedLocationType}"
-                      Margin="0,0,8,8"
-                      materialDesign:HintAssist.Hint="Typ"
-                      IsEnabled="{Binding HasLocation}"/>
+                <ComboBox Grid.Row="0"
+                          Grid.Column="1"
+                          ItemsSource="{Binding LocationTypes}"
+                          SelectedItem="{Binding SelectedLocationType}"
+                          MinHeight="40"
+                          Margin="0,0,0,14"
+                          materialDesign:HintAssist.Hint="Typ"
+                          IsEnabled="{Binding HasLocation}"/>
 
-            <Button Grid.Row="1"
-                    Grid.Column="2"
-                    Command="{Binding SaveCommand}"
-                    Margin="0,0,0,8"
-                    Padding="10,0">
-                <StackPanel Orientation="Horizontal">
-                    <materialDesign:PackIcon Kind="ContentSave" Width="18" Height="18" Margin="0,0,6,0"/>
-                    <TextBlock Text="Ulozit"/>
-                </StackPanel>
-            </Button>
+                <TextBlock Grid.Row="1"
+                           Grid.ColumnSpan="2"
+                           Text="Popis"
+                           Style="{StaticResource CaptionText}"
+                           FontWeight="SemiBold"
+                           Margin="2,0,0,6"/>
 
-            <TextBox Grid.Row="2"
-                     Grid.ColumnSpan="3"
-                     Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
-                     MaxLength="500"
-                     MinHeight="56"
-                     AcceptsReturn="True"
-                     TextWrapping="Wrap"
-                     VerticalScrollBarVisibility="Auto"
-                     materialDesign:HintAssist.Hint="Popis"
-                     IsEnabled="{Binding HasLocation}"/>
-        </Grid>
+                <TextBox Grid.Row="2"
+                         Grid.ColumnSpan="2"
+                         Text="{Binding Description, UpdateSourceTrigger=LostFocus}"
+                         MaxLength="500"
+                         MinHeight="84"
+                         Padding="10,8"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         VerticalScrollBarVisibility="Auto"
+                         VerticalContentAlignment="Top"
+                         IsEnabled="{Binding HasLocation}"/>
+            </Grid>
+        </Expander>
     </Border>
 </UserControl>

--- a/HomeInventory/HomeInventory.Desktop.Wpf/Views/LocationTreeView.xaml
+++ b/HomeInventory/HomeInventory.Desktop.Wpf/Views/LocationTreeView.xaml
@@ -11,16 +11,23 @@
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="30" />
-            <RowDefinition Height="30" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <ComboBox Grid.Row="0"
-           ItemsSource="{Binding Households}"
-           SelectedItem="{Binding SelectedHousehold}"
-           DisplayMemberPath="Name"
-           MinHeight="32"/>
-        <Grid Grid.Row="1">
+
+        <TextBlock Grid.Row="0" Text="Lokace" Style="{StaticResource SectionTitleText}" Margin="0,0,0,10" />
+
+        <ComboBox Grid.Row="1"
+                  ItemsSource="{Binding Households}"
+                  SelectedItem="{Binding SelectedHousehold}"
+                  DisplayMemberPath="Name"
+                  MinHeight="40"
+                  Margin="0,0,0,12"
+                  materialDesign:HintAssist.Hint="Domácnost"/>
+
+        <Grid Grid.Row="2" Margin="0,0,0,14">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
@@ -29,27 +36,35 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             <TextBox Grid.Column="0"
-          Text="{Binding Query, UpdateSourceTrigger=PropertyChanged}"
-          MinHeight="32"
-          VerticalContentAlignment="Center"
-          ToolTip="Hledat (Ctrl+K)"/>
-            <Button Command="{Binding AddLocationCommand}" Margin="0,0,8,0" Grid.Column="1">
+                     Text="{Binding Query, UpdateSourceTrigger=PropertyChanged}"
+                     MinHeight="40"
+                     VerticalContentAlignment="Center"
+                     ToolTip="Hledat lokaci"
+                     materialDesign:HintAssist.Hint="Hledat lokaci"/>
+            <Button Command="{Binding AddLocationCommand}" Grid.Column="1" Style="{StaticResource IconToolButton}" ToolTip="Přidat lokaci">
                 <materialDesign:PackIcon Kind="Add" Width="20" Height="20"/>
             </Button>
-            <Button Command="{Binding DeleteLocationCommand}" Margin="0,0,8,0" Grid.Column="2">
+            <Button Command="{Binding DeleteLocationCommand}" Grid.Column="2" Style="{StaticResource IconToolButton}" ToolTip="Smazat lokaci">
                 <materialDesign:PackIcon Kind="Delete" Width="20" Height="20"/>
             </Button>
             <!--Button Command="{Binding MoveToLocationCommand}" Margin="0,0,8,0" Grid.Column="3">
                 <materialDesign:PackIcon Kind="SwapHorizontal" Width="20" Height="20"/>
             </Button-->
-            <Button Command="{Binding RenameLocationCommand}" Margin="0,0,8,0" Grid.Column="4">
+            <Button Command="{Binding RenameLocationCommand}" Grid.Column="4" Style="{StaticResource IconToolButton}" ToolTip="Přejmenovat lokaci">
                 <materialDesign:PackIcon Kind="Rename" Width="20" Height="20"/>
             </Button>
         </Grid>
-        <TreeView ItemsSource="{Binding RootLocations}" SelectedItemChanged="TreeView_SelectedItemChanged" Grid.Row="2">
+        <TreeView ItemsSource="{Binding RootLocations}"
+                  SelectedItemChanged="TreeView_SelectedItemChanged"
+                  Grid.Row="3"
+                  BorderThickness="0"
+                  Background="Transparent"
+                  Padding="0,2,0,0">
             <TreeView.ItemContainerStyle>
                 <Style TargetType="TreeViewItem">
                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+                    <Setter Property="Padding" Value="2,4" />
+                    <Setter Property="Margin" Value="0,1" />
                 </Style>
             </TreeView.ItemContainerStyle>
             <TreeView.Resources>
@@ -59,14 +74,18 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                     <!-- normal view-->
-                    <TextBlock x:Name="DisplayText" 
-                        Text="{Binding Name, Mode=TwoWay}" />
+                    <TextBlock x:Name="DisplayText"
+                               Text="{Binding Name, Mode=TwoWay}"
+                               Foreground="{StaticResource AppTextBrush}"
+                               FontSize="14"
+                               VerticalAlignment="Center" />
                     
                     <!-- edit mode-->
                     <TextBox x:Name="EditBox"
                                Text="{Binding Name, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                                extensions:FocusExtensions.IsFocused="{Binding ShouldFocusName, Mode=TwoWay}"
                                Visibility="Collapsed"
+                               MinHeight="34"
                                MinWidth="160">
                         <TextBox.InputBindings>
                             <KeyBinding Key="Enter"

--- a/HomeInventory/HomeInventory.Desktop.Wpf/Views/LoginView.xaml
+++ b/HomeInventory/HomeInventory.Desktop.Wpf/Views/LoginView.xaml
@@ -4,12 +4,29 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:HomeInventory.Desktop.Wpf.Views"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
-    <StackPanel Margin="24" Width="320">
-        <TextBlock Text="Login" FontSize="22" Margin="0,0,0,16" />
-        <TextBox Margin="0,0,0,8" Text="{Binding UserName, UpdateSourceTrigger=PropertyChanged}"/>
-        <PasswordBox x:Name="Pwd" PasswordChanged="Pwd_PasswordChanged" Margin="0,0,0,12"/>
-        <Button Content="Přihlásit" Command="{Binding LoginCommand}" />
-    </StackPanel>
+    <Grid Background="{StaticResource AppBackgroundBrush}">
+        <Border Style="{StaticResource SoftPanelBorder}"
+                Padding="28"
+                Width="380"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+            <StackPanel>
+                <TextBlock Text="Přihlášení" Style="{StaticResource PageTitleText}" Margin="0,0,0,6" />
+                <TextBlock Text="Zadejte přístupové údaje k domácnosti." Style="{StaticResource CaptionText}" Margin="0,0,0,22" />
+                <TextBox Margin="0,0,0,12"
+                         MinHeight="42"
+                         materialDesign:HintAssist.Hint="Uživatelské jméno"
+                         Text="{Binding UserName, UpdateSourceTrigger=PropertyChanged}"/>
+                <PasswordBox x:Name="Pwd"
+                             PasswordChanged="Pwd_PasswordChanged"
+                             MinHeight="42"
+                             Margin="0,0,0,18"
+                             materialDesign:HintAssist.Hint="Heslo"/>
+                <Button Content="Přihlásit" Command="{Binding LoginCommand}" Style="{StaticResource PrimaryActionButton}" />
+            </StackPanel>
+        </Border>
+    </Grid>
 </UserControl>

--- a/HomeInventory/HomeInventory.Desktop.Wpf/Views/MainView.xaml
+++ b/HomeInventory/HomeInventory.Desktop.Wpf/Views/MainView.xaml
@@ -11,59 +11,57 @@
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
     </UserControl.Resources>
-    <Grid>
-        <DockPanel LastChildFill="True">
+    <Grid Background="{StaticResource AppBackgroundBrush}">
+        <Grid Margin="20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
+            <Grid Grid.Row="0" Margin="0,0,0,18">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Text="Home Inventory" Style="{StaticResource PageTitleText}" />
+                <TextBlock Grid.Row="1"
+                           Text="Správa místností, úložných prostor a položek v domácnosti"
+                           Style="{StaticResource CaptionText}"
+                           Margin="0,4,0,0" />
+            </Grid>
 
-
-            <!-- MAIN CONTENT -->
-            <Grid>
+            <Grid Grid.Row="1">
                 <Grid.ColumnDefinitions>
-                    <!-- LEFT: locations -->
-                    <ColumnDefinition Width="320" MinWidth="240" />
-                    <!-- splitter -->
-                    <ColumnDefinition Width="6" />
-                    <!-- RIGHT: items/editor/search -->
-                    <ColumnDefinition Width="*" MinWidth="420" />
+                    <ColumnDefinition Width="340" MinWidth="280" />
+                    <ColumnDefinition Width="12" />
+                    <ColumnDefinition Width="*" MinWidth="520" />
                 </Grid.ColumnDefinitions>
 
-                <!-- LEFT PANEL -->
-                <Border Grid.Column="0"
-                    Padding="10"
-                    BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-                    BorderThickness="0,0,1,0">
-                    <!-- LocationTreeViewModel -> LocationTreeView přes DataTemplate -->
+                <Border Grid.Column="0" Style="{StaticResource SoftPanelBorder}" Padding="16">
                     <ContentControl Content="{Binding LocationTree}" />
                 </Border>
 
-                <!-- SPLITTER -->
                 <GridSplitter Grid.Column="1"
-                          HorizontalAlignment="Stretch"
-                          VerticalAlignment="Stretch"
-                          ShowsPreview="True"
-                          ResizeBehavior="PreviousAndNext"
-                          ResizeDirection="Columns" />
+                              Width="12"
+                              Background="Transparent"
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch"
+                              ShowsPreview="True"
+                              ResizeBehavior="PreviousAndNext"
+                              ResizeDirection="Columns" />
 
-                <!-- RIGHT PANEL -->
-                <Border Grid.Column="2"
-                    Padding="12">
-                    <!-- Tady můžeš přepínat obsah (Items list / Item editor / Search results) -->
+                <Border Grid.Column="2" Style="{StaticResource SoftPanelBorder}" Padding="18">
                     <ContentControl Content="{Binding RightPane}" />
                 </Border>
-
-
-
-                
-
             </Grid>
+        </Grid>
 
-        </DockPanel>
-        <Border Background="#66FFFFFF"
+        <Border Style="{StaticResource OverlayPanel}"
             Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}"
-            Panel.ZIndex="10" Grid.Row="1"> 
-            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                <ProgressBar Width="140" Height="6" IsIndeterminate="True"/>
-                <TextBlock Text="Ukládám..." Margin="0,8,0,0" HorizontalAlignment="Center"/>
+            Grid.Row="1">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="220">
+                <ProgressBar Height="6" IsIndeterminate="True"/>
+                <TextBlock Text="Ukládám..." Margin="0,12,0,0" HorizontalAlignment="Center" Style="{StaticResource CaptionText}"/>
             </StackPanel>
         </Border>
         <materialDesign:Snackbar

--- a/HomeInventory/HomeInventory.Desktop.Wpf/Views/RightPaneView.xaml
+++ b/HomeInventory/HomeInventory.Desktop.Wpf/Views/RightPaneView.xaml
@@ -11,7 +11,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Border Grid.Row="0" Padding="0,0,0,12">
+        <Border Grid.Row="0" Padding="0,0,0,18">
             <ContentControl Content="{Binding LocationDetail}" />
         </Border>
 

--- a/HomeInventory/HomeInventory.Desktop.Wpf/Views/ShellWindow.xaml
+++ b/HomeInventory/HomeInventory.Desktop.Wpf/Views/ShellWindow.xaml
@@ -5,10 +5,10 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:HomeInventory.Desktop.Wpf"
         mc:Ignorable="d"
-        Title="Home Inventory" Height="450" Width="800"
+        Title="Home Inventory" Height="720" Width="1120" MinHeight="620" MinWidth="960"
+        Background="{StaticResource AppBackgroundBrush}"
         Style="{StaticResource MaterialDesignWindow}">
-    <Grid>
+    <Grid Background="{StaticResource AppBackgroundBrush}">
         <ContentControl Content="{Binding CurrentViewModel}"/>
-        
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- Refresh WPF app styling, spacing, typography, and panel layout
- Make location detail collapsible with location name and trimmed description in the header
- Remove manual location save button and save committed edits automatically
- Improve item list readability and widen the selection checkbox column

## Verification
- `dotnet build HomeInventory.Desktop.Wpf\HomeInventory.Desktop.Wpf.csproj --no-restore -p:OutputPath=C:\projects\HomeInventory\HomeInventory\artifacts\wpf-build\`

Note: `HomeInventory.Desktop.Wpf.Tests` currently does not compile due to existing `RightPaneViewModelTests` references to an older `RightPaneViewModel` API.